### PR TITLE
Adding missing attributes from current versions of OpenWebUI

### DIFF
--- a/docs/data-sources/model.md
+++ b/docs/data-sources/model.md
@@ -25,6 +25,7 @@ Fetches a model by name.
 - `base_model_id` (String) The ID of the base model.
 - `created_at` (Number) Timestamp when the model was created.
 - `is_active` (Boolean) Whether the model is active.
+- `is_private` (Boolean) Whether the model is private.
 - `meta` (Attributes) Model metadata. (see [below for nested schema](#nestedatt--meta))
 - `name` (String) The name of the model.
 - `params` (Attributes) Model parameters. (see [below for nested schema](#nestedatt--params))
@@ -65,6 +66,7 @@ Read-Only:
 
 - `capabilities` (Attributes) Model capabilities. (see [below for nested schema](#nestedatt--meta--capabilities))
 - `description` (String) Description of the model.
+- `filter_ids` (List of String) List of filter IDs.
 - `profile_image_url` (String) URL for the model's profile image.
 - `tags` (Attributes List) List of tags. (see [below for nested schema](#nestedatt--meta--tags))
 
@@ -98,6 +100,7 @@ Read-Only:
 - `num_batch` (Number) Batch size for processing.
 - `num_ctx` (Number) Context window size.
 - `num_keep` (Number) Number of tokens to keep from prompt.
+- `reasoning_effort` (String) Reasoning effort level.
 - `repeat_last_n` (Number) Number of tokens to consider for repetition penalty.
 - `seed` (Number) Random seed for reproducibility.
 - `stream_response` (Boolean) Whether to stream responses.

--- a/docs/resources/model.md
+++ b/docs/resources/model.md
@@ -25,6 +25,7 @@ Manages a model in OpenWebUI.
 
 - `access_control` (Attributes) Access control settings. (see [below for nested schema](#nestedatt--access_control))
 - `is_active` (Boolean) Whether the model is active.
+- `is_private` (Boolean) Whether the model is private. `access_control` must be unset when this is set to `false`.
 - `meta` (Attributes) Model metadata. (see [below for nested schema](#nestedatt--meta))
 - `params` (Attributes) Model parameters. (see [below for nested schema](#nestedatt--params))
 
@@ -68,6 +69,7 @@ Optional:
 
 - `capabilities` (Attributes) Model capabilities. (see [below for nested schema](#nestedatt--meta--capabilities))
 - `description` (String) Description of the model.
+- `filter_ids` (Set of String) List of filter IDs.
 - `profile_image_url` (String) URL for the model's profile image.
 - `tags` (Attributes List) List of tags. (see [below for nested schema](#nestedatt--meta--tags))
 
@@ -101,6 +103,7 @@ Optional:
 - `num_batch` (Number) Batch size for processing.
 - `num_ctx` (Number) Context window size.
 - `num_keep` (Number) Number of tokens to keep from prompt.
+- `reasoning_effort` (String) Reasoning effort level. If set, must be one of: 'low', 'medium', 'high'.
 - `repeat_last_n` (Number) Number of tokens to consider for repetition penalty.
 - `seed` (Number) Random seed for reproducibility.
 - `stream_response` (Boolean) Whether to stream responses.

--- a/docs/resources/model.md
+++ b/docs/resources/model.md
@@ -18,6 +18,7 @@ Manages a model in OpenWebUI.
 ### Required
 
 - `base_model_id` (String) The ID of the base model.
+- `id` (String) The ID of the model.
 - `name` (String) The name of the model.
 
 ### Optional
@@ -30,7 +31,6 @@ Manages a model in OpenWebUI.
 ### Read-Only
 
 - `created_at` (Number) Timestamp when the model was created.
-- `id` (String) The ID of the model.
 - `updated_at` (Number) Timestamp when the model was last updated.
 - `user_id` (String) The ID of the user who created the model.
 

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,8 @@ go 1.23.0
 toolchain go1.24.1
 
 require (
-	github.com/google/uuid v1.6.0
 	github.com/hashicorp/terraform-plugin-framework v1.14.1
+	github.com/hashicorp/terraform-plugin-framework-validators v0.17.0
 	github.com/hashicorp/terraform-plugin-go v0.26.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/C
 github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/terraform-plugin-framework v1.14.1 h1:jaT1yvU/kEKEsxnbrn4ZHlgcxyIfjvZ41BLdlLk52fY=
 github.com/hashicorp/terraform-plugin-framework v1.14.1/go.mod h1:xNUKmvTs6ldbwTuId5euAtg37dTxuyj3LHS3uj7BHQ4=
+github.com/hashicorp/terraform-plugin-framework-validators v0.17.0 h1:0uYQcqqgW3BMyyve07WJgpKorXST3zkpzvrOnf3mpbg=
+github.com/hashicorp/terraform-plugin-framework-validators v0.17.0/go.mod h1:VwdfgE/5Zxm43flraNa0VjcvKQOGVrcO4X8peIri0T0=
 github.com/hashicorp/terraform-plugin-go v0.26.0 h1:cuIzCv4qwigug3OS7iKhpGAbZTiypAfFQmw8aE65O2M=
 github.com/hashicorp/terraform-plugin-go v0.26.0/go.mod h1:+CXjuLDiFgqR+GcrM5a2E2Kal5t5q2jb0E3D57tTdNY=
 github.com/hashicorp/terraform-plugin-log v0.9.0 h1:i7hOA+vdAItN1/7UrfBqBwvYPQ9TFvymaRGZED3FCV0=

--- a/internal/provider/client/models/client.go
+++ b/internal/provider/client/models/client.go
@@ -105,10 +105,13 @@ func (c *Client) CreateModel(model *Model) (*Model, error) {
 			apiModel.Params.System = model.Params.System.ValueString()
 		}
 		if !model.Params.StreamResponse.IsNull() {
-			apiModel.Params.StreamResponse = model.Params.StreamResponse.ValueBool()
+			apiModel.Params.StreamResponse = model.Params.StreamResponse.ValueBoolPointer()
 		}
 		if !model.Params.Temperature.IsNull() {
 			apiModel.Params.Temperature = model.Params.Temperature.ValueFloat64()
+		}
+		if !model.Params.ReasoningEffort.IsNull() {
+			apiModel.Params.ReasoningEffort = model.Params.ReasoningEffort.ValueString()
 		}
 		if !model.Params.TopP.IsNull() {
 			apiModel.Params.TopP = model.Params.TopP.ValueFloat64()
@@ -167,6 +170,15 @@ func (c *Client) CreateModel(model *Model) (*Model, error) {
 					apiModel.Meta.Tags[i] = APITag{
 						Name: tag.Name.ValueString(),
 					}
+				}
+			}
+		}
+
+		if len(model.Meta.FilterIDs) > 0 {
+			apiModel.Meta.FilterIDs = make([]string, len(model.Meta.FilterIDs))
+			for i, id := range model.Meta.FilterIDs {
+				if !id.IsNull() {
+					apiModel.Meta.FilterIDs[i] = id.ValueString()
 				}
 			}
 		}
@@ -261,10 +273,13 @@ func (c *Client) UpdateModel(id string, model *Model) (*Model, error) {
 			apiModel.Params.System = model.Params.System.ValueString()
 		}
 		if !model.Params.StreamResponse.IsNull() {
-			apiModel.Params.StreamResponse = model.Params.StreamResponse.ValueBool()
+			apiModel.Params.StreamResponse = model.Params.StreamResponse.ValueBoolPointer()
 		}
 		if !model.Params.Temperature.IsNull() {
 			apiModel.Params.Temperature = model.Params.Temperature.ValueFloat64()
+		}
+		if !model.Params.ReasoningEffort.IsNull() {
+			apiModel.Params.ReasoningEffort = model.Params.ReasoningEffort.ValueString()
 		}
 		if !model.Params.TopP.IsNull() {
 			apiModel.Params.TopP = model.Params.TopP.ValueFloat64()
@@ -323,6 +338,15 @@ func (c *Client) UpdateModel(id string, model *Model) (*Model, error) {
 					apiModel.Meta.Tags[i] = APITag{
 						Name: tag.Name.ValueString(),
 					}
+				}
+			}
+		}
+
+		if len(model.Meta.FilterIDs) > 0 {
+			apiModel.Meta.FilterIDs = make([]string, len(model.Meta.FilterIDs))
+			for i, id := range model.Meta.FilterIDs {
+				if !id.IsNull() {
+					apiModel.Meta.FilterIDs[i] = id.ValueString()
 				}
 			}
 		}

--- a/internal/provider/client/models/client.go
+++ b/internal/provider/client/models/client.go
@@ -10,8 +10,6 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
-
-	"github.com/google/uuid"
 )
 
 // Client implements the models operations
@@ -92,12 +90,9 @@ func (c *Client) GetModels() ([]Model, error) {
 }
 
 func (c *Client) CreateModel(model *Model) (*Model, error) {
-	// Generate a new UUID for the model
-	modelID := uuid.New().String()
-
 	// Convert to API model
 	apiModel := &APIModel{
-		ID:          modelID,
+		ID:          model.ID.ValueString(),
 		BaseModelID: model.BaseModelID.ValueString(),
 		Name:        model.Name.ValueString(),
 		IsActive:    model.IsActive.ValueBool(),
@@ -245,11 +240,6 @@ func (c *Client) CreateModel(model *Model) (*Model, error) {
 	var createdAPIModel APIModel
 	if err := json.Unmarshal(bodyBytes, &createdAPIModel); err != nil {
 		return nil, fmt.Errorf("error decoding response: %v", err)
-	}
-
-	// Ensure the ID is set in the response
-	if createdAPIModel.ID == "" {
-		createdAPIModel.ID = modelID
 	}
 
 	return APIToModel(&createdAPIModel), nil

--- a/internal/provider/models_data_source.go
+++ b/internal/provider/models_data_source.go
@@ -66,6 +66,10 @@ func (d *ModelDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, 
 						Description: "Sampling temperature.",
 						Computed:    true,
 					},
+					"reasoning_effort": schema.StringAttribute{
+						Description: "Reasoning effort level.",
+						Computed:    true,
+					},
 					"top_p": schema.Float64Attribute{
 						Description: "Top-p sampling parameter.",
 						Computed:    true,
@@ -150,6 +154,11 @@ func (d *ModelDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, 
 							},
 						},
 					},
+					"filter_ids": schema.ListAttribute{
+						Description: "List of filter IDs.",
+						Computed:    true,
+						ElementType: types.StringType,
+					},
 				},
 			},
 			"access_control": schema.SingleNestedAttribute{
@@ -200,6 +209,10 @@ func (d *ModelDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, 
 			},
 			"updated_at": schema.Int64Attribute{
 				Description: "Timestamp when the model was last updated.",
+				Computed:    true,
+			},
+			"is_private": schema.BoolAttribute{
+				Description: "Whether the model is private.",
 				Computed:    true,
 			},
 		},

--- a/internal/provider/models_resource.go
+++ b/internal/provider/models_resource.go
@@ -401,11 +401,11 @@ func (r *ModelResource) ImportState(ctx context.Context, req resource.ImportStat
 type AccessControlDefaultModifier struct{}
 
 func (m AccessControlDefaultModifier) Description(ctx context.Context) string {
-	return "implement me description"
+	return "Ensures access_control is set to default values when is_private is true."
 }
 
 func (m AccessControlDefaultModifier) MarkdownDescription(ctx context.Context) string {
-	return "implement me md description"
+	return "Ensures access_control is set to default values when is_private is true."
 }
 
 // PlanModifyObject implements the plan modification logic.

--- a/internal/provider/models_resource.go
+++ b/internal/provider/models_resource.go
@@ -65,10 +65,7 @@ func (r *ModelResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description: "The ID of the model.",
-				Computed:    true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
+				Required:    true,
 			},
 			"user_id": schema.StringAttribute{
 				Description: "The ID of the user who created the model.",


### PR DESCRIPTION
This pull request includes several updates to the model documentation and codebase to support new attributes and improve functionality. The most important changes involve adding new attributes to the model schema, updating the client code to handle these attributes, and modifying the resource schema to include default values and validators.

### Documentation Updates:
* Added `is_private`, `filter_ids`, and `reasoning_effort` attributes to the model documentation in `docs/data-sources/model.md` and `docs/resources/model.md`. [[1]](diffhunk://#diff-9692880420a197e1fd6767e72a873339faf45e1fe20bf2cb2df01179e6ae3083R28) [[2]](diffhunk://#diff-9692880420a197e1fd6767e72a873339faf45e1fe20bf2cb2df01179e6ae3083R69) [[3]](diffhunk://#diff-9692880420a197e1fd6767e72a873339faf45e1fe20bf2cb2df01179e6ae3083R103) [[4]](diffhunk://#diff-9e4b5da6648b4e53664f28e22322f50d3e1da27cd4ffba63727797340e20ddfaR21-L33) [[5]](diffhunk://#diff-9e4b5da6648b4e53664f28e22322f50d3e1da27cd4ffba63727797340e20ddfaR72) [[6]](diffhunk://#diff-9e4b5da6648b4e53664f28e22322f50d3e1da27cd4ffba63727797340e20ddfaR106)

### Codebase Updates:
* Updated the `go.mod` file to include new dependencies: `github.com/hashicorp/terraform-plugin-framework-validators`.
* Removed `github.com/google/uuid` from `internal/provider/client/models/client.go` and updated the `CreateModel` and `UpdateModel` methods to handle new attributes and pointer types. [[1]](diffhunk://#diff-b6baa21a239c8f1be5c1f64abfa015520bd476f8d18ecb65ee3e7840b8279a56L13-L14) [[2]](diffhunk://#diff-b6baa21a239c8f1be5c1f64abfa015520bd476f8d18ecb65ee3e7840b8279a56L95-R95) [[3]](diffhunk://#diff-b6baa21a239c8f1be5c1f64abfa015520bd476f8d18ecb65ee3e7840b8279a56L113-R115) [[4]](diffhunk://#diff-b6baa21a239c8f1be5c1f64abfa015520bd476f8d18ecb65ee3e7840b8279a56R176-R184) [[5]](diffhunk://#diff-b6baa21a239c8f1be5c1f64abfa015520bd476f8d18ecb65ee3e7840b8279a56L250-L254) [[6]](diffhunk://#diff-b6baa21a239c8f1be5c1f64abfa015520bd476f8d18ecb65ee3e7840b8279a56L274-R283) [[7]](diffhunk://#diff-b6baa21a239c8f1be5c1f64abfa015520bd476f8d18ecb65ee3e7840b8279a56R344-R352)
* Added new attributes `IsPrivate`, `ReasoningEffort`, and `FilterIDs` to the `Model` and `ModelParams` structs in `internal/provider/client/models/types.go`. [[1]](diffhunk://#diff-8a38cbb60f438ded9c0a0830ba52aa98b861a6f634409dbb645b2b50b918386aR20) [[2]](diffhunk://#diff-8a38cbb60f438ded9c0a0830ba52aa98b861a6f634409dbb645b2b50b918386aR44) [[3]](diffhunk://#diff-8a38cbb60f438ded9c0a0830ba52aa98b861a6f634409dbb645b2b50b918386aL56-R61) [[4]](diffhunk://#diff-8a38cbb60f438ded9c0a0830ba52aa98b861a6f634409dbb645b2b50b918386aR78-R86) [[5]](diffhunk://#diff-8a38cbb60f438ded9c0a0830ba52aa98b861a6f634409dbb645b2b50b918386aL141-R154) [[6]](diffhunk://#diff-8a38cbb60f438ded9c0a0830ba52aa98b861a6f634409dbb645b2b50b918386aR212-R218) [[7]](diffhunk://#diff-8a38cbb60f438ded9c0a0830ba52aa98b861a6f634409dbb645b2b50b918386aR247-R249)
* Updated the `ModelDataSource` and `ModelResource` schemas to include new attributes, default values, and validators in `internal/provider/models_data_source.go` and `internal/provider/models_resource.go`. [[1]](diffhunk://#diff-958584453fdde0f4c7f18e9aa3c3dd608a90e551a0313636b6c3e9e0e197bd6bR69-R72) [[2]](diffhunk://#diff-958584453fdde0f4c7f18e9aa3c3dd608a90e551a0313636b6c3e9e0e197bd6bR157-R161) [[3]](diffhunk://#diff-958584453fdde0f4c7f18e9aa3c3dd608a90e551a0313636b6c3e9e0e197bd6bR214-R217) [[4]](diffhunk://#diff-36f0d17251b9dbd3986337685b9f19f7614b4c16e5d6ed27f158e825c3d3827bR10-R21) [[5]](diffhunk://#diff-36f0d17251b9dbd3986337685b9f19f7614b4c16e5d6ed27f158e825c3d3827bL68-R74) [[6]](diffhunk://#diff-36f0d17251b9dbd3986337685b9f19f7614b4c16e5d6ed27f158e825c3d3827bR90-R122) [[7]](diffhunk://#diff-36f0d17251b9dbd3986337685b9f19f7614b4c16e5d6ed27f158e825c3d3827bR136-R142) [[8]](diffhunk://#diff-36f0d17251b9dbd3986337685b9f19f7614b4c16e5d6ed27f158e825c3d3827bR192-R193)